### PR TITLE
Burn COMMS TLC

### DIFF
--- a/Subsystems/COMMS/comms.c
+++ b/Subsystems/COMMS/comms.c
@@ -543,7 +543,7 @@ void process_telecommand(uint8_t tlc_data[]) {
 		  break;
 
 		case POL_BURNCOMMS_SHUT:
-			//TBD
+			HAL_GPIO_WritePin(GPIOB, GPIO_PIN_11, GPIO_PIN_RESET);
 		  break;
 
 		case POL_HEATER_SHUT:
@@ -559,7 +559,9 @@ void process_telecommand(uint8_t tlc_data[]) {
 		  break;
 
 		case POL_BURNCOMMS_ENABLE:
-			//TBD
+			HAL_GPIO_WritePin(GPIOB, GPIO_PIN_11, GPIO_PIN_SET);
+			vTaskDelay(15000);
+			HAL_GPIO_WritePin(GPIOB, GPIO_PIN_11, GPIO_PIN_RESET);
 		  break;
 
 		case POL_HEATER_ENABLE://TBD


### PR DESCRIPTION
GPIO Set and Reset on PB11, time set to 15s with a freq. of 1 tick per 1ms. Fix time dependency. Tested and burned, less than 15s required